### PR TITLE
Dismiss error dialog when destroying send activity

### DIFF
--- a/app/src/main/java/io/phore/android/ui/transaction_send_activity/SendActivity.java
+++ b/app/src/main/java/io/phore/android/ui/transaction_send_activity/SendActivity.java
@@ -251,6 +251,12 @@ public class SendActivity extends BaseActivity implements View.OnClickListener {
     }
 
     @Override
+    public void onDestroy() {
+        super.onDestroy();
+		dismissErrorDialog();
+    }
+
+    @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         getMenuInflater().inflate(R.menu.send_menu,menu);
         return super.onCreateOptionsMenu(menu);
@@ -579,6 +585,12 @@ public class SendActivity extends BaseActivity implements View.OnClickListener {
 
         super.onActivityResult(requestCode, resultCode, data);
     }
+
+    private void dismissErrorDialog() {
+		if (errorDialog != null) {
+			errorDialog.dismiss();
+		}
+	}
 
     private void showErrorDialog(int resStr){
         showErrorDialog(getString(resStr));


### PR DESCRIPTION
This should fix the errors that happen when quickly exiting the send screen. I wasn't able to reproduce the error, but from the logcat.txts this seems to be the issue.